### PR TITLE
fix(retry): retry field is retry not delay

### DIFF
--- a/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEConnectionImpl.java
@@ -63,12 +63,12 @@ public class SSEConnectionImpl implements SSEConnection {
 
 	@Override
 	public SSEConnection retry(Long delay, List<String> data) {
-		return withHeader("delay", delay.toString(), data);
+		return withHeader("retry", delay.toString(), data);
 	}
 
 	@Override
 	public SSEConnection retry(Long delay, String data) {
-		return withHeader("delay", delay.toString(), data);
+		return withHeader("retry", delay.toString(), data);
 	}
 
 	@Override


### PR DESCRIPTION
The W3C SSE specification for the [retry](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) is to send "retry" as field. Current implementation was returning "delay" instead.