### PR TITLE
fix(SSEHandlerImp): shouldn't reject connection when no Accept header

### DIFF
--- a/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEHandlerImpl.java
+++ b/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEHandlerImpl.java
@@ -27,7 +27,7 @@ public class SSEHandlerImpl implements SSEHandler {
 		response.setChunked(true);
 		SSEConnection connection = SSEConnection.create(context);
 		String accept = request.getHeader("Accept");
-		if (accept == null || !accept.contains("text/event-stream")) {
+		if (accept != null && !accept.contains("text/event-stream")) {
 			connection.reject(406, "Not acceptable");
 			return;
 		}

--- a/src/test/java/io/vertx/ext/web/handler/sse/TestRequestResponseHeaders.java
+++ b/src/test/java/io/vertx/ext/web/handler/sse/TestRequestResponseHeaders.java
@@ -10,10 +10,21 @@ import org.junit.runner.RunWith;
 public class TestRequestResponseHeaders extends TestBase {
 
 	@Test
+	public void noHeaderTextEventStreamHttpRequest(TestContext context) {
+		final Async async = context.async();
+		client().get("/sse", response -> {
+			context.assertEquals(406, response.statusCode());
+			async.complete();
+		}).putHeader("Accept", "foo").end();
+	}
+
+	@Test
 	public void noHeaderHttpRequest(TestContext context) {
 		final Async async = context.async();
 		client().getNow("/sse", response -> {
-			context.assertEquals(406, response.statusCode());
+			context.assertEquals("text/event-stream", response.getHeader("Content-Type"));
+			context.assertEquals("no-cache", response.getHeader("Cache-Control"));
+			context.assertEquals("keep-alive", response.getHeader("Connection"));
 			async.complete();
 		});
 	}


### PR DESCRIPTION
Hello,
When a client tries to connect to the SSEHandler with no `Accept` header (eg via a curl), the connection is rejected with a `406`.
The spec (https://www.w3.org/TR/2015/REC-eventsource-20150203/#text-event-stream) says however:

> For HTTP connections, the Accept header may be included; if included, it must contain only formats of event framing that are supported by the user agent (one of which must be text/event-stream, as described below).

So, in case there is no Accept header, the connection shouldn't be rejected.

The fix changes the condition of the SSEHandlerImpl to only reject connections when there
is `Accept` headers that don't include "text/event-stream". If there is no `Accept` header, there is no rejection.

Note: the latest spec (https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) doesn't mention this anymore.