### PR TITLE
Add Jenkinsfile for CI and fix for consecutive messages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,25 @@
+pipeline {
+    agent any
+    stages {
+        stage ('Clone sources') {
+            steps {
+                checkout scm
+                prepareGradleInit()
+            }
+        }
+
+        stage ('Gradle build') {
+            steps {
+                script { gradleBuild "clean", "build", "check", "assemble" }
+            }
+        }
+
+        stage ('trigger deployment') {
+            steps {
+                noReview {
+                    script { gradlePublish "assemble" }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/vertx/ext/web/handler/sse/impl/EventSourceImpl.java
+++ b/src/main/java/io/vertx/ext/web/handler/sse/impl/EventSourceImpl.java
@@ -107,22 +107,23 @@ public class EventSourceImpl implements EventSource {
 			String header = currentPacket.headerName;
 			if (header == null) {
 				messageHandler.handle(currentPacket.toString());
-				return;
+			} else {
+				switch (currentPacket.headerName) {
+					case "event":
+						handler = eventHandlers.get(currentPacket.headerValue);
+						break;
+					case "id":
+						handler = messageHandler;
+						lastId = currentPacket.headerValue;
+						break;
+					case "retry":
+						// FIXME : we should automatically handle this ?
+				}
+				if (handler != null) {
+					handler.handle(currentPacket.toString());
+				}
 			}
-			switch (currentPacket.headerName) {
-				case "event":
-					handler = eventHandlers.get(currentPacket.headerValue);
-					break;
-				case "id":
-					handler = messageHandler;
-					lastId = currentPacket.headerValue;
-					break;
-				case "retry":
-					// FIXME : we should automatically handle this ?
-			}
-			if (handler != null) {
-				handler.handle(currentPacket.toString());
-			}
+			currentPacket = null;
 		}
 	}
 }


### PR DESCRIPTION
I noticed consecutive consumer callbacks would still see old messages as well.
If the producer sends 'A', 'B', 'C', the consumer would receive
* 'A'
* 'A', 'B'
* 'A', 'B', 'C'
